### PR TITLE
Create vision subsystem

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2023.1.1"
+    id "edu.wpi.first.GradleRIO" version "2023.2.1"
     id 'com.diffplug.spotless' version '6.12.0'
 }
 

--- a/src/main/java/frc3512/lib/vision/EstimatedRobotPose.java
+++ b/src/main/java/frc3512/lib/vision/EstimatedRobotPose.java
@@ -1,0 +1,47 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 PhotonVision
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package frc3512.lib.vision;
+
+import edu.wpi.first.math.geometry.Pose3d;
+
+/** An estimated pose based on pipeline result */
+public class EstimatedRobotPose {
+  /** The estimated pose */
+  public final Pose3d estimatedPose;
+
+  /** The estimated time the frame used to derive the robot pose was taken */
+  public final double timestampSeconds;
+
+  /**
+   * Constructs an EstimatedRobotPose
+   *
+   * @param estimatedPose estimated pose
+   * @param timestampSeconds timestamp of the estimate
+   */
+  public EstimatedRobotPose(Pose3d estimatedPose, double timestampSeconds) {
+    this.estimatedPose = estimatedPose;
+    this.timestampSeconds = timestampSeconds;
+  }
+}

--- a/src/main/java/frc3512/lib/vision/PhotonPoseEstimator.java
+++ b/src/main/java/frc3512/lib/vision/PhotonPoseEstimator.java
@@ -1,0 +1,493 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022 PhotonVision
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package frc3512.lib.vision;
+
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.math.Pair;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Translation3d;
+import edu.wpi.first.wpilibj.DriverStation;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.photonvision.PhotonCamera;
+import org.photonvision.targeting.PhotonPipelineResult;
+import org.photonvision.targeting.PhotonTrackedTarget;
+
+/**
+ * The PhotonPoseEstimator class filters or combines readings from all the fiducials visible at a
+ * given timestamp on the field to produce a single robot in field pose, using the strategy set
+ * below. Example usage can be found in our apriltagExample example project.
+ */
+public class PhotonPoseEstimator {
+  /** Position estimation strategies that can be used by the {@link PhotonPoseEstimator} class. */
+  public enum PoseStrategy {
+    /** Choose the Pose with the lowest ambiguity. */
+    LOWEST_AMBIGUITY,
+
+    /** Choose the Pose which is closest to the camera height. */
+    CLOSEST_TO_CAMERA_HEIGHT,
+
+    /** Choose the Pose which is closest to a set Reference position. */
+    CLOSEST_TO_REFERENCE_POSE,
+
+    /** Choose the Pose which is closest to the last pose calculated */
+    CLOSEST_TO_LAST_POSE,
+
+    /** Choose the Pose with the lowest ambiguity. */
+    AVERAGE_BEST_TARGETS
+  }
+
+  private AprilTagFieldLayout fieldTags;
+  private PoseStrategy strategy;
+  private final PhotonCamera camera;
+  private final Transform3d robotToCamera;
+
+  private Pose3d lastPose;
+  private Pose3d referencePose;
+  private final Set<Integer> reportedErrors = new HashSet<>();
+
+  /**
+   * Create a new PhotonPoseEstimator.
+   *
+   * @param fieldTags A WPILib {@link AprilTagFieldLayout} linking AprilTag IDs to Pose3ds with
+   *     respect to the FIRST field.
+   * @param strategy The strategy it should use to determine the best pose.
+   * @param camera PhotonCameras and
+   * @param robotToCamera Transform3d from the center of the robot to the camera mount positions
+   *     (ie, robot ➔ camera).
+   */
+  public PhotonPoseEstimator(
+      AprilTagFieldLayout fieldTags,
+      PoseStrategy strategy,
+      PhotonCamera camera,
+      Transform3d robotToCamera) {
+    this.fieldTags = fieldTags;
+    this.strategy = strategy;
+    this.camera = camera;
+    this.robotToCamera = robotToCamera;
+  }
+
+  /**
+   * Get the AprilTagFieldLayout being used by the PositionEstimator.
+   *
+   * @return the AprilTagFieldLayout
+   */
+  public AprilTagFieldLayout getFieldTags() {
+    return fieldTags;
+  }
+
+  /**
+   * Set the AprilTagFieldLayout being used by the PositionEstimator.
+   *
+   * @param fieldTags the AprilTagFieldLayout
+   */
+  public void setFieldTags(AprilTagFieldLayout fieldTags) {
+    this.fieldTags = fieldTags;
+  }
+
+  /**
+   * Get the Position Estimation Strategy being used by the Position Estimator.
+   *
+   * @return the strategy
+   */
+  public PoseStrategy getStrategy() {
+    return strategy;
+  }
+
+  /**
+   * Set the Position Estimation Strategy used by the Position Estimator.
+   *
+   * @param strategy the strategy to set
+   */
+  public void setStrategy(PoseStrategy strategy) {
+    this.strategy = strategy;
+  }
+
+  /**
+   * Return the reference position that is being used by the estimator.
+   *
+   * @return the referencePose
+   */
+  public Pose3d getReferencePose() {
+    return referencePose;
+  }
+
+  /**
+   * Update the stored reference pose for use when using the <b>CLOSEST_TO_REFERENCE_POSE</b>
+   * strategy.
+   *
+   * @param referencePose the referencePose to set
+   */
+  public void setReferencePose(Pose3d referencePose) {
+    this.referencePose = referencePose;
+  }
+
+  /**
+   * Update the stored reference pose for use when using the <b>CLOSEST_TO_REFERENCE_POSE</b>
+   * strategy.
+   *
+   * @param referencePose the referencePose to set
+   */
+  public void setReferencePose(Pose2d referencePose) {
+    this.referencePose = new Pose3d(referencePose);
+  }
+
+  /**
+   * Update the stored last pose. Useful for setting the initial estimate when using the
+   * <b>CLOSEST_TO_LAST_POSE</b> strategy.
+   *
+   * @param lastPose the lastPose to set
+   */
+  public void setLastPose(Pose3d lastPose) {
+    this.lastPose = lastPose;
+  }
+
+  /**
+   * Update the stored last pose. Useful for setting the initial estimate when using the
+   * <b>CLOSEST_TO_LAST_POSE</b> strategy.
+   *
+   * @param lastPose the lastPose to set
+   */
+  public void setLastPose(Pose2d lastPose) {
+    this.lastPose = new Pose3d(lastPose);
+  }
+
+  /**
+   * Poll data from the configured cameras and update the estimated position of the robot. Returns
+   * empty if there are no cameras set or no targets were found from the cameras.
+   *
+   * @return an EstimatedRobotPose with an estimated pose, and information about the camera(s) and
+   *     pipeline results used to create the estimate
+   */
+  public Optional<EstimatedRobotPose> update() {
+    if (camera == null) {
+      DriverStation.reportError("[PhotonPoseEstimator] Missing camera!", false);
+      return Optional.empty();
+    }
+
+    PhotonPipelineResult cameraResult = camera.getLatestResult();
+    if (!cameraResult.hasTargets()) {
+      return Optional.empty();
+    }
+
+    Optional<EstimatedRobotPose> estimatedPose;
+    switch (strategy) {
+      case LOWEST_AMBIGUITY:
+        estimatedPose = lowestAmbiguityStrategy(cameraResult);
+        break;
+      case CLOSEST_TO_CAMERA_HEIGHT:
+        estimatedPose = closestToCameraHeightStrategy(cameraResult);
+        break;
+      case CLOSEST_TO_LAST_POSE:
+        setReferencePose(lastPose);
+      case CLOSEST_TO_REFERENCE_POSE:
+        estimatedPose = closestToReferencePoseStrategy(cameraResult, referencePose);
+        break;
+      case AVERAGE_BEST_TARGETS:
+        estimatedPose = averageBestTargetsStrategy(cameraResult);
+        break;
+      default:
+        DriverStation.reportError(
+            "[PhotonPoseEstimator] Unknown Position Estimation Strategy!", false);
+        return Optional.empty();
+    }
+
+    if (estimatedPose.isEmpty()) {
+      lastPose = null;
+    }
+
+    return estimatedPose;
+  }
+
+  /**
+   * Return the estimated position of the robot with the lowest position ambiguity from a List of
+   * pipeline results.
+   *
+   * @param result pipeline result
+   * @return the estimated position of the robot in the FCS and the estimated timestamp of this
+   *     estimation.
+   */
+  private Optional<EstimatedRobotPose> lowestAmbiguityStrategy(PhotonPipelineResult result) {
+    PhotonTrackedTarget lowestAmbiguityTarget = null;
+
+    double lowestAmbiguityScore = 10;
+
+    for (PhotonTrackedTarget target : result.targets) {
+      double targetPoseAmbiguity = target.getPoseAmbiguity();
+      // Make sure the target is a Fiducial target.
+      if (targetPoseAmbiguity != -1 && targetPoseAmbiguity < lowestAmbiguityScore) {
+        lowestAmbiguityScore = targetPoseAmbiguity;
+        lowestAmbiguityTarget = target;
+      }
+    }
+
+    // Although there are confirmed to be targets, none of them may be fiducial
+    // targets.
+    if (lowestAmbiguityTarget == null) return Optional.empty();
+
+    int targetFiducialId = lowestAmbiguityTarget.getFiducialId();
+
+    Optional<Pose3d> targetPosition = fieldTags.getTagPose(targetFiducialId);
+
+    if (targetPosition.isEmpty()) {
+      reportFiducialPoseError(targetFiducialId);
+      return Optional.empty();
+    }
+
+    return Optional.of(
+        new EstimatedRobotPose(
+            targetPosition
+                .get()
+                .transformBy(lowestAmbiguityTarget.getBestCameraToTarget().inverse())
+                .transformBy(robotToCamera.inverse()),
+            result.getTimestampSeconds()));
+  }
+
+  /**
+   * Return the estimated position of the robot using the target with the lowest delta height
+   * difference between the estimated and actual height of the camera.
+   *
+   * @param result pipeline result
+   * @return the estimated position of the robot in the FCS and the estimated timestamp of this
+   *     estimation.
+   */
+  private Optional<EstimatedRobotPose> closestToCameraHeightStrategy(PhotonPipelineResult result) {
+    double smallestHeightDifference = 10e9;
+    EstimatedRobotPose closestHeightTarget = null;
+
+    for (PhotonTrackedTarget target : result.targets) {
+      int targetFiducialId = target.getFiducialId();
+
+      // Don't report errors for non-fiducial targets. This could also be resolved by
+      // adding -1 to
+      // the initial HashSet.
+      if (targetFiducialId == -1) continue;
+
+      Optional<Pose3d> targetPosition = fieldTags.getTagPose(target.getFiducialId());
+
+      if (targetPosition.isEmpty()) {
+        reportFiducialPoseError(target.getFiducialId());
+        continue;
+      }
+
+      double alternateTransformDelta =
+          Math.abs(
+              robotToCamera.getZ()
+                  - targetPosition
+                      .get()
+                      .transformBy(target.getAlternateCameraToTarget().inverse())
+                      .getZ());
+      double bestTransformDelta =
+          Math.abs(
+              robotToCamera.getZ()
+                  - targetPosition
+                      .get()
+                      .transformBy(target.getBestCameraToTarget().inverse())
+                      .getZ());
+
+      if (alternateTransformDelta < smallestHeightDifference) {
+        smallestHeightDifference = alternateTransformDelta;
+        closestHeightTarget =
+            new EstimatedRobotPose(
+                targetPosition
+                    .get()
+                    .transformBy(target.getAlternateCameraToTarget().inverse())
+                    .transformBy(robotToCamera.inverse()),
+                result.getTimestampSeconds());
+      }
+
+      if (bestTransformDelta < smallestHeightDifference) {
+        smallestHeightDifference = bestTransformDelta;
+        closestHeightTarget =
+            new EstimatedRobotPose(
+                targetPosition
+                    .get()
+                    .transformBy(target.getBestCameraToTarget().inverse())
+                    .transformBy(robotToCamera.inverse()),
+                result.getTimestampSeconds());
+      }
+    }
+
+    // Need to null check here in case none of the provided targets are fiducial.
+    return Optional.ofNullable(closestHeightTarget);
+  }
+
+  /**
+   * Return the estimated position of the robot using the target with the lowest delta in the vector
+   * magnitude between it and the reference pose.
+   *
+   * @param result pipeline result
+   * @param referencePose reference pose to check vector magnitude difference against.
+   * @return the estimated position of the robot in the FCS and the estimated timestamp of this
+   *     estimation.
+   */
+  private Optional<EstimatedRobotPose> closestToReferencePoseStrategy(
+      PhotonPipelineResult result, Pose3d referencePose) {
+    if (referencePose == null) {
+      DriverStation.reportError(
+          "[PhotonPoseEstimator] Tried to use reference pose strategy without setting the reference!",
+          false);
+      return Optional.empty();
+    }
+
+    double smallestPoseDelta = 10e9;
+    EstimatedRobotPose lowestDeltaPose = null;
+
+    for (PhotonTrackedTarget target : result.targets) {
+      int targetFiducialId = target.getFiducialId();
+
+      // Don't report errors for non-fiducial targets. This could also be resolved by
+      // adding -1 to
+      // the initial HashSet.
+      if (targetFiducialId == -1) continue;
+
+      Optional<Pose3d> targetPosition = fieldTags.getTagPose(target.getFiducialId());
+
+      if (targetPosition.isEmpty()) {
+        reportFiducialPoseError(targetFiducialId);
+        continue;
+      }
+
+      Pose3d altTransformPosition =
+          targetPosition
+              .get()
+              .transformBy(target.getAlternateCameraToTarget().inverse())
+              .transformBy(robotToCamera.inverse());
+      Pose3d bestTransformPosition =
+          targetPosition
+              .get()
+              .transformBy(target.getBestCameraToTarget().inverse())
+              .transformBy(robotToCamera.inverse());
+
+      double altDifference = Math.abs(calculateDifference(referencePose, altTransformPosition));
+      double bestDifference = Math.abs(calculateDifference(referencePose, bestTransformPosition));
+
+      if (altDifference < smallestPoseDelta) {
+        smallestPoseDelta = altDifference;
+        lowestDeltaPose =
+            new EstimatedRobotPose(altTransformPosition, result.getTimestampSeconds());
+      }
+      if (bestDifference < smallestPoseDelta) {
+        smallestPoseDelta = bestDifference;
+        lowestDeltaPose =
+            new EstimatedRobotPose(bestTransformPosition, result.getTimestampSeconds());
+      }
+    }
+    return Optional.ofNullable(lowestDeltaPose);
+  }
+
+  /**
+   * Return the average of the best target poses using ambiguity as weight.
+   *
+   * @param result pipeline result
+   * @return the estimated position of the robot in the FCS and the estimated timestamp of this
+   *     estimation.
+   */
+  private Optional<EstimatedRobotPose> averageBestTargetsStrategy(PhotonPipelineResult result) {
+    List<Pair<PhotonTrackedTarget, Pose3d>> estimatedRobotPoses = new ArrayList<>();
+    double totalAmbiguity = 0;
+
+    for (PhotonTrackedTarget target : result.targets) {
+      int targetFiducialId = target.getFiducialId();
+
+      // Don't report errors for non-fiducial targets. This could also be resolved by
+      // adding -1 to
+      // the initial HashSet.
+      if (targetFiducialId == -1) continue;
+
+      Optional<Pose3d> targetPosition = fieldTags.getTagPose(target.getFiducialId());
+
+      if (targetPosition.isEmpty()) {
+        reportFiducialPoseError(targetFiducialId);
+        continue;
+      }
+
+      double targetPoseAmbiguity = target.getPoseAmbiguity();
+
+      // Pose ambiguity is 0, use that pose
+      if (targetPoseAmbiguity == 0) {
+        return Optional.of(
+            new EstimatedRobotPose(
+                targetPosition
+                    .get()
+                    .transformBy(target.getBestCameraToTarget().inverse())
+                    .transformBy(robotToCamera.inverse()),
+                result.getTimestampSeconds()));
+      }
+
+      totalAmbiguity += 1.0 / target.getPoseAmbiguity();
+
+      estimatedRobotPoses.add(
+          new Pair<>(
+              target,
+              targetPosition
+                  .get()
+                  .transformBy(target.getBestCameraToTarget().inverse())
+                  .transformBy(robotToCamera.inverse())));
+    }
+
+    // Take the average
+
+    Translation3d transform = new Translation3d();
+    Rotation3d rotation = new Rotation3d();
+
+    if (estimatedRobotPoses.isEmpty()) return Optional.empty();
+
+    for (Pair<PhotonTrackedTarget, Pose3d> pair : estimatedRobotPoses) {
+      // Total ambiguity is non-zero confirmed because if it was zero, that pose was
+      // returned.
+      double weight = (1.0 / pair.getFirst().getPoseAmbiguity()) / totalAmbiguity;
+      Pose3d estimatedPose = pair.getSecond();
+      transform = transform.plus(estimatedPose.getTranslation().times(weight));
+      rotation = rotation.plus(estimatedPose.getRotation().times(weight));
+    }
+
+    return Optional.of(
+        new EstimatedRobotPose(new Pose3d(transform, rotation), result.getTimestampSeconds()));
+  }
+
+  /**
+   * Difference is defined as the vector magnitude between the two poses
+   *
+   * @return The absolute "difference" (>=0) between two Pose3ds.
+   */
+  private double calculateDifference(Pose3d x, Pose3d y) {
+    return x.getTranslation().getDistance(y.getTranslation());
+  }
+
+  private void reportFiducialPoseError(int fiducialId) {
+    if (!reportedErrors.contains(fiducialId)) {
+      DriverStation.reportError(
+          "[PhotonPoseEstimator] Tried to get pose of unknown April Tag: " + fiducialId, false);
+      reportedErrors.add(fiducialId);
+    }
+  }
+}

--- a/src/main/java/frc3512/robot/Constants.java
+++ b/src/main/java/frc3512/robot/Constants.java
@@ -2,7 +2,10 @@ package frc3512.robot;
 
 import com.revrobotics.CANSparkMax.IdleMode;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.math.util.Units;
 import frc3512.lib.util.SwerveModuleConstants;
@@ -29,6 +32,18 @@ public final class Constants {
 
     // 2nd Xbox controller port
     public static final int xboxController2Port = 1;
+  }
+
+  /** Constants revolving around the vision subsystem. */
+  public static final class VisionConstants {
+    // Camera name
+    public static final String cameraName = "OV5647";
+
+    // Robot to camera transform
+    public static final Transform3d robotToCam =
+        new Transform3d(
+            new Translation3d(0.0, Units.inchesToMeters(1.5), Units.inchesToMeters(39.0)),
+            new Rotation3d(0.0, 0.0, 0.0));
   }
 
   /** Constants revolving around the swerve subsystem */

--- a/src/main/java/frc3512/robot/RobotContainer.java
+++ b/src/main/java/frc3512/robot/RobotContainer.java
@@ -8,13 +8,15 @@ import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import frc3512.robot.commands.TeleopSwerve;
 import frc3512.robot.subsystems.Swerve;
+import frc3512.robot.subsystems.Vision;
 
 public class RobotContainer {
   // Auton Chooser
   private final SendableChooser<Command> m_autonChooser = new SendableChooser<Command>();
 
   // Robot subsystems
-  private Swerve m_swerve = new Swerve();
+  private Vision m_vision = new Vision();
+  private Swerve m_swerve = new Swerve(m_vision);
 
   // Xbox controllers
   private final CommandXboxController driver =
@@ -45,7 +47,7 @@ public class RobotContainer {
             m_swerve,
             () -> -driver.getRawAxis(translationAxis),
             () -> -driver.getRawAxis(strafeAxis),
-            () -> -driver.getRawAxis(rotationAxis),
+            () -> driver.getRawAxis(rotationAxis),
             () -> driver.rightStick().getAsBoolean()));
   }
 

--- a/src/main/java/frc3512/robot/commands/AimAtTag.java
+++ b/src/main/java/frc3512/robot/commands/AimAtTag.java
@@ -1,0 +1,43 @@
+package frc3512.robot.commands;
+
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc3512.robot.subsystems.Swerve;
+import frc3512.robot.subsystems.Vision;
+
+public class AimAtTag extends CommandBase {
+  private final Swerve s_Swerve;
+  private final Vision m_vision;
+  private final Timer timer = new Timer();
+
+  public AimAtTag(Swerve swerve, Vision vision) {
+    this.s_Swerve = swerve;
+    this.m_vision = vision;
+
+    addRequirements(s_Swerve, vision);
+  }
+
+  @Override
+  public void initialize() {
+    timer.reset();
+  }
+
+  @Override
+  public void execute() {
+    timer.start();
+    double rotationSpeed = -s_Swerve.controller.calculate(m_vision.getYaw(), 0);
+    s_Swerve.drive(new Translation2d(), rotationSpeed, true, true);
+  }
+
+  @Override
+  public void end(boolean interrupted) {
+    timer.stop();
+    s_Swerve.drive(new Translation2d(), 0.0, true, true);
+  }
+
+  @Override
+  public boolean isFinished() {
+    return s_Swerve.controller.atSetpoint() || timer.hasElapsed(1.0);
+  }
+}

--- a/src/main/java/frc3512/robot/subsystems/Swerve.java
+++ b/src/main/java/frc3512/robot/subsystems/Swerve.java
@@ -1,7 +1,7 @@
 package frc3512.robot.subsystems;
 
 import com.ctre.phoenix.sensors.BasePigeonSimCollection;
-import com.ctre.phoenix.sensors.WPI_Pigeon2;
+import com.ctre.phoenix.sensors.Pigeon2;
 import com.revrobotics.REVPhysicsSim;
 
 import edu.wpi.first.math.controller.PIDController;
@@ -23,9 +23,9 @@ import frc3512.lib.logging.SpartanPose2dEntry;
 import frc3512.robot.Constants;
 
 public class Swerve extends SubsystemBase {
-  private final WPI_Pigeon2 gyro;
-  private final BasePigeonSimCollection gyroSim;
-  double yawSim = 0.0;
+  private final Pigeon2 gyro;
+  private double yawSim = 0.0;
+  private BasePigeonSimCollection gyroSim;
 
   private final Vision vision;
 
@@ -41,7 +41,7 @@ public class Swerve extends SubsystemBase {
   /** Subsystem class for the swerve drive. */
   public Swerve(Vision vision) {
     this.vision = vision;
-    gyro = new WPI_Pigeon2(Constants.SwerveConstants.pigeonID);
+    gyro = new Pigeon2(Constants.SwerveConstants.pigeonID);
     gyroSim = gyro.getSimCollection();
     gyro.configFactoryDefault();
     zeroGyro();

--- a/src/main/java/frc3512/robot/subsystems/Swerve.java
+++ b/src/main/java/frc3512/robot/subsystems/Swerve.java
@@ -3,7 +3,6 @@ package frc3512.robot.subsystems;
 import com.ctre.phoenix.sensors.BasePigeonSimCollection;
 import com.ctre.phoenix.sensors.Pigeon2;
 import com.revrobotics.REVPhysicsSim;
-
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.estimator.SwerveDrivePoseEstimator;
 import edu.wpi.first.math.geometry.Pose2d;

--- a/src/main/java/frc3512/robot/subsystems/SwerveModule.java
+++ b/src/main/java/frc3512/robot/subsystems/SwerveModule.java
@@ -4,6 +4,7 @@ import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.kinematics.SwerveModulePosition;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
+import edu.wpi.first.wpilibj.RobotBase;
 import frc3512.lib.logging.SpartanDoubleEntry;
 import frc3512.lib.motion.SpartanCANCoder;
 import frc3512.lib.motion.SpartanSparkMax;
@@ -129,10 +130,15 @@ public class SwerveModule {
 
     angleMotor.performPositionControl(angle.getDegrees());
     lastAngle = angle;
+
+    if (RobotBase.isSimulation()) {
+      driveMotor.updateSimVelocity(desiredState);
+      angleMotor.setCurrentAngle(angle.getDegrees());
+    }
   }
 
   private Rotation2d getAngle() {
-    return Rotation2d.fromDegrees(angleMotor.getPosition());
+    return Rotation2d.fromDegrees(angleMotor.getAngle());
   }
 
   public Rotation2d getCanCoder() {

--- a/src/main/java/frc3512/robot/subsystems/Vision.java
+++ b/src/main/java/frc3512/robot/subsystems/Vision.java
@@ -1,0 +1,98 @@
+package frc3512.robot.subsystems;
+
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.apriltag.AprilTagFieldLayout.OriginPosition;
+import edu.wpi.first.apriltag.AprilTagFields;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.DriverStation.Alliance;
+import edu.wpi.first.wpilibj.RobotBase;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc3512.lib.logging.SpartanDoubleEntry;
+import frc3512.lib.vision.EstimatedRobotPose;
+import frc3512.lib.vision.PhotonPoseEstimator;
+import frc3512.lib.vision.PhotonPoseEstimator.PoseStrategy;
+import frc3512.robot.Constants;
+import java.io.IOException;
+import java.util.Optional;
+import org.photonvision.PhotonCamera;
+import org.photonvision.PhotonUtils;
+import org.photonvision.targeting.PhotonPipelineResult;
+import org.photonvision.targeting.PhotonTrackedTarget;
+
+public class Vision extends SubsystemBase {
+  private PhotonCamera camera;
+  private PhotonPoseEstimator estimator;
+  private AprilTagFieldLayout layout;
+
+  private PhotonPipelineResult result;
+  private PhotonTrackedTarget bestTarget;
+  private boolean haveTargets = false;
+  private double lastYaw = 0.0;
+
+  private SpartanDoubleEntry yawEntry;
+
+  public Vision() {
+    camera = new PhotonCamera(Constants.VisionConstants.cameraName);
+    PhotonCamera.setVersionCheckEnabled(false);
+
+    try {
+      layout = AprilTagFieldLayout.loadFromResource(AprilTagFields.kDefaultField.m_resourceFile);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+
+    if (DriverStation.getAlliance() == Alliance.Blue) {
+      layout.setOrigin(OriginPosition.kBlueAllianceWallRightSide);
+    } else if (DriverStation.getAlliance() == Alliance.Red) {
+      layout.setOrigin(OriginPosition.kRedAllianceWallRightSide);
+    }
+
+    estimator =
+        new PhotonPoseEstimator(
+            layout,
+            PoseStrategy.CLOSEST_TO_REFERENCE_POSE,
+            camera,
+            Constants.VisionConstants.robotToCam);
+
+    yawEntry = new SpartanDoubleEntry("/Diagnostics/Vision/Yaw");
+  }
+
+  public boolean hasTargets() {
+    return haveTargets;
+  }
+
+  public double getYaw() {
+    if (haveTargets) {
+      return bestTarget.getYaw();
+    } else {
+      return lastYaw;
+    }
+  }
+
+  public double getRange(Pose2d robotPose, Pose2d targetPose) {
+    if (haveTargets) {
+      return PhotonUtils.getDistanceToPose(robotPose, targetPose);
+    } else {
+      return 0.0;
+    }
+  }
+
+  public Optional<EstimatedRobotPose> estimateGlobalPose(Pose2d previousPose) {
+    estimator.setReferencePose(previousPose);
+    return estimator.update();
+  }
+
+  @Override
+  public void periodic() {
+    if (RobotBase.isReal()) {
+      result = camera.getLatestResult();
+      bestTarget = result.getBestTarget();
+      haveTargets = result.hasTargets();
+      if (haveTargets) {
+        lastYaw = bestTarget.getYaw();
+      }
+      yawEntry.set(lastYaw);
+    }
+  }
+}


### PR DESCRIPTION
Create the vision subsystem to read and take in information from AprilTags. Uses them in basic information like yaw/pitch and also is used in providing vision information to the swerve drive's pose estimation.